### PR TITLE
Fixed removal of incorrect recycle bin in the editor

### DIFF
--- a/Assets/RecyclerKit/Editor/TrashManEditor.cs
+++ b/Assets/RecyclerKit/Editor/TrashManEditor.cs
@@ -266,7 +266,7 @@ public class TrashManEditor : Editor
 			EditorGUILayout.BeginHorizontal();
 			_prefabFoldouts[n] = EditorGUILayout.Foldout( _prefabFoldouts[n], prefabPool.prefab.name, EditorStyles.foldout );
 			if( GUILayout.Button( "-", buttonStyle, GUILayout.Width( 20f ) ) && EditorUtility.DisplayDialog( "Remove Recycle Bin", "Are you sure you want to remove this recycle bin?", "Yes", "Cancel" ) )
-				_trashManTarget.recycleBinCollection.RemoveAt( _trashManTarget.recycleBinCollection.Count - 1 );
+				_trashManTarget.recycleBinCollection.RemoveAt( n );
 			EditorGUILayout.EndHorizontal();
 
 			if( _prefabFoldouts[n] )


### PR DESCRIPTION
-Removal of a recycle bin in the editor was using recycleBinCollection.Count - 1 instead of the actual index of the bin to be removed.