### PR TITLE
Prevent UI scale change

### DIFF
--- a/Assets/RecyclerKit/TrashMan.cs
+++ b/Assets/RecyclerKit/TrashMan.cs
@@ -141,7 +141,7 @@ public partial class TrashMan : MonoBehaviour
 
 #if UNITY_4_6 || UNITY_5_0
                 if (newTransform as RectTransform)
-                    newTransform.SetParent(null, true);
+                    newTransform.SetParent(null, false);
                 else
 #endif
 				    newTransform.parent = null;
@@ -233,7 +233,7 @@ public partial class TrashMan : MonoBehaviour
 
 #if UNITY_4_6 || UNITY_5_0
             if (newGo.transform as RectTransform != null)
-                newGo.transform.SetParent(null, true);
+                newGo.transform.SetParent(null, false);
             else
 #endif
 			    newGo.transform.parent = null;
@@ -281,7 +281,7 @@ public partial class TrashMan : MonoBehaviour
 
 #if UNITY_4_6 || UNITY_5_0
             if (go.transform as RectTransform != null)
-                go.transform.SetParent(instance.transform, true);
+                go.transform.SetParent(instance.transform, false);
             else
 #endif
                 go.transform.parent = instance.transform;


### PR DESCRIPTION
As per http://docs.unity3d.com/460/Documentation/Manual/HOWTO-UICreateFromScripting.html:

> **Instantiating the UI element**
> 
> Prefabs of UI elements are instantiated as normal using the Instantiate method. When setting the parent of the instantiated UI element, it’s recommended to do it using the Transform.SetParent method with the worldPositionStays parameter set to false.

If worldPositionStays is set to _true_ then we can get spawned UI-element with incorrect scaling.
